### PR TITLE
gsub out the AUTO_INCREMENT part of creating table

### DIFF
--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -170,7 +170,8 @@ module Apartment
       #
       def load_or_abort_sql(file)
         if File.exists?(file)
-          sql_statements = File.read(file).split(";").map{ |q| q.strip }
+          # Get rid of AUTO_INCREMENT, see http://stackoverflow.com/questions/2210719/out-of-sync-auto-increment-values-in-development-structure-sql-from-rails-mysql
+          sql_statements = File.read(file).split(";").map{ |q| q.strip.gsub(/ AUTO_INCREMENT=\d*/, '') }
           sql_statements.each { |sql| Apartment.connection.execute( sql ) }
         else
           abort %{#{file} doesn't exist yet}


### PR DESCRIPTION
AUTO_INCREMENT values in structure.sql get out-of-sync as we develop in parallel. New sites created should start at 1. And it potentially breaks tests
